### PR TITLE
Fix Docs build

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -30,6 +30,7 @@ var packFiles = "./src/**/*.csproj";
 var testFiles = "./test/**/*.csproj";
 var packages = "./artifacts/*.nupkg";
 DirectoryPath sitePath = "./artifacts/docs";
+var docFxConfig = "./docs/docfx.json";
 
 var coverallsToken = EnvironmentVariable("COVERALLS_TOKEN");
 var sonarToken = EnvironmentVariable("SONAR_TOKEN");
@@ -234,7 +235,11 @@ Task("SonarEnd")
 Task("BuildDocs")
     .Does(() => 
     {
-        DocFxBuild("./docs/docfx.json");
+        Information("Extracting API Metadata")
+        DocFxMetadata(docFxConfig);
+        
+        Information("Building Docs")
+        DocFxBuild(docFxConfig);
     });
 
 Task("ServeDocs")

--- a/build.cake
+++ b/build.cake
@@ -235,10 +235,10 @@ Task("SonarEnd")
 Task("BuildDocs")
     .Does(() => 
     {
-        Information("Extracting API Metadata")
+        Information("Extracting API Metadata");
         DocFxMetadata(docFxConfig);
         
-        Information("Building Docs")
+        Information("Building Docs");
         DocFxBuild(docFxConfig);
     });
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -3,9 +3,9 @@
     {
       "src": [
         {
-          "src": "../",
+          "src": "../src",
           "files": [
-            "src/**/*.csproj"
+            "**/*.csproj"
           ],
           "exclude": [
             "**/bin/**",


### PR DESCRIPTION
Turns out you need to run docfx metadata before build hence why API docs weren't building